### PR TITLE
Openssl as a thirdparty fix (proper type for a submodule and commit which builds)

### DIFF
--- a/kos/php/cross-build.sh
+++ b/kos/php/cross-build.sh
@@ -37,7 +37,7 @@ fi
 
 export PATH="$SDK_PREFIX/toolchain/bin:$PATH"
 
-(cd $SCRIPT_DIR/../../ && git submodule update --init --depth=1 third_party/openssl && cd third_party/openssl && ./config && make build_generated)
+(cd $SCRIPT_DIR/../../ && git submodule update --init --depth=1 third_party/openssl && cd third_party/openssl && git checkout 830bf8e1e4749ad65c51b6a1d0d769ae689404ba && ./config && make build_generated)
 
 $SDK_PREFIX/toolchain/bin/cmake -G "Unix Makefiles" \
       -D CMAKE_BUILD_TYPE:STRING=Release \


### PR DESCRIPTION
This PR fixes thirdparty openssl issues:
- thirdparty proper type (otherwise not able to update submodule)
- cross-build.sh git checkout to a specific commit, because project can't be build on latest

It looks like to be better move out the git thing from cross-build.sh completely and use commit hash which is part of submodule inclusion already.